### PR TITLE
Don't override previous_tab and indent_backwards shortcuts on OSX

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -22,11 +22,14 @@
 
 ////
 //// Movement & navigation
-,{
-	"keys": ["ctrl+super+f"],
-	"command": "paredit_forward",
-	"context": [{"key": "should_paredit"}]
- }
+//
+// Overrides OS X fullscreen, and is already available on
+// in OS X via ctrl+option+f
+// ,{
+// 	"keys": ["ctrl+super+f"],
+//	"command": "paredit_forward",
+//	"context": [{"key": "should_paredit"}]
+//  }
 ,{
 	"keys": ["ctrl+super+b"],
 	"command": "paredit_backward",

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -44,12 +44,12 @@
 	"context": [{"key": "should_paredit"}]
  }
 ,{
-	"keys": ["ctrl+super+["],
+	"keys": ["alt+["],
 	"command": "paredit_wrap_square",
 	"context": [{"key": "should_paredit"}]
  }
 ,{
-	"keys": ["ctrl+super+shift+["],
+	"keys": ["alt+shift+["],
 	"command": "paredit_wrap_curly",
 	"context": [{"key": "should_paredit"}]
  }

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -41,12 +41,12 @@
 	"context": [{"key": "should_paredit"}]
  }
 ,{
-	"keys": ["super+["],
+	"keys": ["ctrl+super+["],
 	"command": "paredit_wrap_square",
 	"context": [{"key": "should_paredit"}]
  }
 ,{
-	"keys": ["super+shift+["],
+	"keys": ["ctrl+super+shift+["],
 	"command": "paredit_wrap_curly",
 	"context": [{"key": "should_paredit"}]
  }


### PR DESCRIPTION
Prior to this commit, the shortcuts for these `paredit_wrap_square` and `paredit_wrap_curly` were overriding the OS X shortcuts for the `previous_tab` and `indent_backwards` commands built into Sublime.

The addition of `ctrl+` definitely makes these two shortcuts more cumbersome, but I think it's best not to override two of the most used built-in Sublime shortcuts.

This also disables Paredit's `ctrl+super+f` shortcut, which conflicts with Sublime's fullscreen shortcut on OS X. As far as I can tell, `paredit_forward` and `paredit_backward` mimic functionality that is already built into OS X and available almost globally via `ctrl+option+f` and `ctrl+option+b`. Should we maybe disable `paredit_backward` in the OS X keyboard defaults, as well? 

Happy to change this to another set shortcut if you have a better idea :dancer: 
