### PR TITLE
Better ctrl+k

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -64,12 +64,18 @@
 ,{
 	"keys": ["ctrl+k"],
 	"command": "paredit_kill",
-	"context": [{"key": "should_paredit"}]
+	"context": [
+		{"key": "should_paredit"},
+		{"key": "inside_expression"}
+	]
  }
 ,{
 	"keys": ["ctrl+shift+k"],
 	"command": "paredit_kill_expression",
-	"context": [{"key": "should_paredit"}]
+	"context": [
+		{"key": "should_paredit"},
+		{"key": "inside_expression"}
+	]
  }
 ,{
 	"keys": ["alt+delete"],

--- a/shared.py
+++ b/shared.py
@@ -353,10 +353,17 @@ def should_paredit(view):
 	        (is_correct_syntax(view) or
 	         is_correct_file_ending(view)))
 
+def inside_expression(view):
+	return get_expression(view, view.sel()[0].a) != (None, None)
+
 class PareditListenerCommand(sublime_plugin.EventListener):
 	def on_query_context(self, view, key, operator, operand, match_all):
 		if key == "should_paredit":
 			return should_paredit(view)
+
+		if key == "inside_expression":
+			return inside_expression(view)
+
 
 class Paredit_toggle_enableCommand(sublime_plugin.ApplicationCommand):
 	def run(self):

--- a/shared.py
+++ b/shared.py
@@ -364,7 +364,6 @@ class PareditListenerCommand(sublime_plugin.EventListener):
 		if key == "inside_expression":
 			return inside_expression(view)
 
-
 class Paredit_toggle_enableCommand(sublime_plugin.ApplicationCommand):
 	def run(self):
 		set_enabled(not is_enabled())


### PR DESCRIPTION
In OS X, `ctrl+k` is a system-wide command for deleting from the cursor to the end of line, and `ctrl+shift+k` will kill the entire line. This was being overridden by the `paredit_kill` and `paredit_kill_expression` key-mappings. The `paredit_kill` and `paredit_kill_expression` commands are mega-helpful, but even in LISP, there are times that you may want to kill to the end of the line while not inside of an expression.

My solution was simply to check whether or not the cursor is inside of an expression before using Paredit's function. If you're outside of an expression, the normal behavior for your platform will occur.

Thanks!
