### PR TITLE
make package settings menu consistent with other plugins

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -6,15 +6,47 @@
   "children":
   [
     {
-      "caption": "Paredit",
-      "children": [
-        {"caption": "Enabled", "checkbox": true, "command": "paredit_toggle_enable"},
-        {"caption": "Settings", "command": "open_file", "args":
-          {"file": "${packages}/paredit/paredit.sublime-settings"}},
-        {"caption": "Key Bindings – Default", "command": "open_file", "args":
-          {"file": "${packages}/paredit/Default.sublime-keymap"}},
-        {"caption": "Key Bindings – OSX", "command": "open_file", "args":
-          {"file": "${packages}/paredit/Default (OSX).sublime-keymap"}}
+      "caption": "Package Settings",
+      "mnemonic": "P",
+      "id": "package-settings",
+      "children":
+      [
+        {
+          "caption": "Paredit",
+          "children": [
+            {"caption": "Enabled", "checkbox": true, "command": "paredit_toggle_enable"},
+            { "caption": "-" },
+            {"caption": "Settings - Default", "command": "open_file", "args":
+              {"file": "${packages}/paredit/paredit.sublime-settings"}},
+            {"caption": "Settings - User", "command": "open_file", "args":
+              {"file": "${packages}/User/paredit.sublime-settings"}},
+            { "caption": "-" },
+            {"caption": "Key Bindings – Default", "command": "open_file", "args": {
+              "file": "${packages}/paredit/Default (OSX).sublime-keymap",
+              "platform": "OSX"
+            }},
+            {"caption": "Key Bindings – Default", "command": "open_file", "args": {
+              "file": "${packages}/paredit/Default.sublime-keymap",
+              "platform": "Linux"
+            }},
+            {"caption": "Key Bindings – Default", "command": "open_file", "args": {
+              "file": "${packages}/paredit/Default.sublime-keymap",
+              "platform": "Windows"
+            }},
+            {"caption": "Key Bindings – User", "command": "open_file", "args": {
+              "file": "${packages}/User/Default (OSX).sublime-keymap",
+              "platform": "OSX"
+            }},
+            {"caption": "Key Bindings – User", "command": "open_file", "args": {
+              "file": "${packages}/User/Default.sublime-keymap",
+              "platform": "Linux"
+            }},
+            {"caption": "Key Bindings – User", "command": "open_file", "args": {
+              "file": "${packages}/User/Default.sublime-keymap",
+              "platform": "Windows"
+            }}
+          ]
+        }
       ]
     }
   ]


### PR DESCRIPTION
Fixes Issue #12
- Puts the Paredit package settings menu under `Preferences > Package Settings`
- Adds separate entries for "Default" and "User" preferences so that users can correctly change and save preferences
- Automatically opens the correct keybindings file for the platform
- Adds nice separators to the menu
